### PR TITLE
Feature/multiple trackers

### DIFF
--- a/phxd/server/__init__.py
+++ b/phxd/server/__init__.py
@@ -216,8 +216,9 @@ class HLServer(Factory):
                     self.sendUserChange(user)
 
     def pingTracker(self):
-        try:
-            tracker.send_update(conf.TRACKER_ADDRESS, conf.TRACKER_PORT, int(self.startTime), conf.SERVER_NAME,
-                    conf.SERVER_DESCRIPTION, conf.SERVER_PORTS[0], len(self.userlist), conf.TRACKER_PASSWORD)
-        except:
-            logging.exception('error pinging tracker')
+        for tracker_conf in conf.TRACKERS:
+            try:
+                tracker.send_update(tracker_conf['ADDRESS'], tracker_conf['PORT'], int(self.startTime), conf.SERVER_NAME,
+                        conf.SERVER_DESCRIPTION, conf.SERVER_PORTS[0], len(self.userlist), tracker_conf['PASSWORD'])
+            except:
+                logging.exception('error pinging tracker')

--- a/phxd/server/config/default.py
+++ b/phxd/server/config/default.py
@@ -38,9 +38,10 @@ SSL_CERT_FILE = 'certs/cacert.pem'
 ################################################################################
 
 ENABLE_TRACKER_REGISTER = False
-TRACKER_ADDRESS = "hltracker.com"
-TRACKER_PORT = 5499
-TRACKER_PASSWORD = ""
+TRACKERS = [
+  {'ADDRESS': 'address1', 'PORT': 5499, 'PASSWORD': 'secret'},
+  {'ADDRESS': 'address2', 'PORT': 5499, 'PASSWORD': 'secret'},
+]
 TRACKER_INTERVAL = 5 * 60
 SERVER_DESCRIPTION = "My phxd server."
 


### PR DESCRIPTION
What is this feature?
-----------
- Support multiple tracker updates for a server
- Change is *not* backwards compatible with original server/config/default.py schema

Configuration Examples
-----------

Previous Configuration (Snippet):
> ENABLE_TRACKER_REGISTER = False
TRACKER_ADDRESS = "hltracker.com"
TRACKER_PORT = 5499
TRACKER_PASSWORD = ""
TRACKER_INTERVAL = 5 * 60
SERVER_DESCRIPTION = "My phxd server."

New Configuration (Snippet):
> ENABLE_TRACKER_REGISTER = False
TRACKERS = [
  {'ADDRESS': 'address1', 'PORT': 5499, 'PASSWORD': 'secret'},
  {'ADDRESS': 'address2', 'PORT': 5499, 'PASSWORD': 'secret'},
]
TRACKER_INTERVAL = 5 * 60
SERVER_DESCRIPTION = "My phxd server."`